### PR TITLE
feat(suggested-search): add suggested filters to mobile web

### DIFF
--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -211,6 +211,12 @@ export const BaseArtworkFilter: React.FC<
   const extendedFiltersCount =
     revisedArtworkFiltersCount - quickArtworkFiltersCount
 
+  // Count only what the button hides, or a pill's filter reads as active twice.
+  // `sort` stays counted — this button opens it too.
+  const mobileFiltersCount = QuickFilters
+    ? appliedFiltersTotalCount - quickArtworkFiltersCount
+    : appliedFiltersTotalCount
+
   /**
    * Check to see if the current filter is different from the previous filter
    * and trigger a reload.
@@ -341,10 +347,10 @@ export const BaseArtworkFilter: React.FC<
                     <FilterIcon />
                     <Text variant="xs">
                       Sort & Filter
-                      {appliedFiltersTotalCount > 0 && (
+                      {mobileFiltersCount > 0 && (
                         <Box as="span" color="brand">
                           {" "}
-                          • {appliedFiltersTotalCount}
+                          • {mobileFiltersCount}
                         </Box>
                       )}
                     </Text>
@@ -364,6 +370,17 @@ export const BaseArtworkFilter: React.FC<
             )
           }}
         </Sticky>
+
+        {/* Opt-in: a page arriving pre-filtered needs the cause on screen */}
+        {QuickFilters && (
+          <>
+            <Spacer y={2} />
+
+            <FullBleed>
+              <HorizontalOverflow px={2}>{QuickFilters}</HorizontalOverflow>
+            </FullBleed>
+          </>
+        )}
 
         <Spacer y={4} />
 

--- a/src/Components/Search/Mobile/Overlay.tsx
+++ b/src/Components/Search/Mobile/Overlay.tsx
@@ -186,6 +186,7 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
           <SearchResultsListPaginationContainer
             viewer={viewer}
             query={inputValue}
+            debouncedQuery={debouncedValue}
             selectedPill={selectedPill}
             onClose={onClose}
           />

--- a/src/Components/Search/Mobile/SearchResultsList.tsx
+++ b/src/Components/Search/Mobile/SearchResultsList.tsx
@@ -1,5 +1,7 @@
 import {
   ActionType,
+  ContextModule,
+  type RailViewed,
   type SearchedWithNoResults,
   type SearchedWithResults,
   type SelectedItemFromSearch,
@@ -10,15 +12,19 @@ import {
   SuggestionItem,
   type SuggestionItemOptionProps,
 } from "Components/Search/SuggestionItem/SuggestionItem"
-import type { PillType } from "Components/Search/constants"
+import { SuggestedFiltersItem } from "Components/Search/SuggestedFiltersItem"
+import { TOP_PILL, type PillType } from "Components/Search/constants"
 import { useRecentSearches } from "Components/Search/hooks/useRecentSearches"
+import { buildSuggestedFiltersUrl } from "Components/Search/utils/buildSuggestedFiltersUrl"
+import { parseFilterQuery } from "Components/Search/utils/parseFilterQuery"
 import {
   type SearchNodeOption,
   formatOptions,
 } from "Components/Search/utils/formatOptions"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import type { SearchResultsList_viewer$data } from "__generated__/SearchResultsList_viewer.graphql"
-import { type FC, useEffect } from "react"
+import { useFlag } from "@unleash/proxy-client-react"
+import { type FC, useEffect, useMemo, useRef } from "react"
 import {
   type RelayPaginationProp,
   createPaginationContainer,
@@ -32,20 +38,52 @@ interface SearchResultsListProps {
   relay: RelayPaginationProp
   viewer: SearchResultsList_viewer$data
   query: string
+  /** Debounced, so the suggested-filters row doesn't flicker per keystroke */
+  debouncedQuery: string
   selectedPill: PillType
   onClose: () => void
 }
 
 const ENTITIES_PER_SCROLL = 10
 
-const SearchResultsList: FC<
+export const SearchResultsList: FC<
   React.PropsWithChildren<SearchResultsListProps>
-> = ({ relay, viewer, query, selectedPill, onClose }) => {
+> = ({ relay, viewer, query, debouncedQuery, selectedPill, onClose }) => {
   const tracking = useTracking()
   const { addRecentSearchFromOption } = useRecentSearches()
   const { contextPageOwnerType, contextPageOwnerId, contextPageOwnerSlug } =
     useAnalyticsContext()
   const edges = viewer.searchConnection?.edges ?? []
+
+  const isSuggestedFiltersEnabled = useFlag("onyx_suggested-filters")
+
+  // Gated here, so users who can't see the row don't pay to parse
+  const parsedFilters = useMemo(() => {
+    if (!isSuggestedFiltersEnabled) return null
+
+    return parseFilterQuery(debouncedQuery)
+  }, [debouncedQuery, isSuggestedFiltersEnabled])
+
+  // The entity pills scope to a single type, where browsing artworks is off-topic
+  const shouldShowSuggestedFilters =
+    !!parsedFilters && selectedPill === TOP_PILL
+
+  // Once per overlay session; per keystroke would inflate the CTR denominator
+  const hasTrackedSuggestedFiltersRef = useRef(false)
+
+  useEffect(() => {
+    if (!shouldShowSuggestedFilters) return
+    if (hasTrackedSuggestedFiltersRef.current) return
+
+    hasTrackedSuggestedFiltersRef.current = true
+
+    const event: RailViewed = {
+      action: ActionType.railViewed,
+      context_module: ContextModule.suggestedFilters,
+      context_screen: contextPageOwnerType,
+    }
+    tracking.trackEvent(event)
+  }, [shouldShowSuggestedFilters, contextPageOwnerType, tracking.trackEvent])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
@@ -89,12 +127,73 @@ const SearchResultsList: FC<
     }) as SearchNodeOption[],
   )
 
+  const suggestedFiltersHref = parsedFilters
+    ? buildSuggestedFiltersUrl(parsedFilters)
+    : ""
+
+  // Shared by the tracking event and the recent-searches entry, as on desktop
+  const suggestedFiltersOption: SuggestionItemOptionProps = {
+    kind: "suggestedFilters",
+    text: debouncedQuery,
+    value: debouncedQuery,
+    subtitle: "",
+    imageUrl: "",
+    showAuctionResultsButton: false,
+    href: suggestedFiltersHref,
+    typename: "SuggestedFilters",
+    item_id: "suggested-filters",
+    // Position within its own context module, not the entity ranking
+    item_number: 0,
+    item_type: "filter-suggestion",
+  }
+
+  const handleSuggestedFiltersClick = () => {
+    const event: SelectedItemFromSearch = {
+      action: ActionType.selectedItemFromSearch,
+      // Its own module, separable from entity results
+      context_module: ContextModule.suggestedFilters,
+      destination_path: suggestedFiltersOption.href,
+      query: debouncedQuery,
+      item_id: suggestedFiltersOption.item_id!,
+      item_number: suggestedFiltersOption.item_number!,
+      item_type: suggestedFiltersOption.item_type!,
+    }
+
+    tracking.trackEvent(event)
+    addRecentSearchFromOption(suggestedFiltersOption)
+    onClose()
+  }
+
+  // Kept in the loading and empty states: with no entity match, this is the
+  // only answer left
+  const suggestedFiltersRow =
+    shouldShowSuggestedFilters && parsedFilters ? (
+      <SuggestedFiltersItem
+        parsed={parsedFilters}
+        href={suggestedFiltersHref}
+        query={debouncedQuery}
+        onClick={handleSuggestedFiltersClick}
+      />
+    ) : null
+
   if (!viewer.searchConnection) {
-    return <ContentPlaceholder />
+    return (
+      <>
+        {suggestedFiltersRow}
+
+        <ContentPlaceholder />
+      </>
+    )
   }
 
   if (formattedOptions.length === 0) {
-    return <NoResults query={query} mt={4} mx={2} />
+    return (
+      <>
+        {suggestedFiltersRow}
+
+        <NoResults query={query} mt={4} mx={2} />
+      </>
+    )
   }
 
   const handleLoadMore = () => {
@@ -133,6 +232,8 @@ const SearchResultsList: FC<
 
   return (
     <>
+      {suggestedFiltersRow}
+
       {formattedOptions.map((option, index) => {
         return (
           <SuggestionItem

--- a/src/Components/Search/Mobile/__tests__/SearchResultsList.jest.tsx
+++ b/src/Components/Search/Mobile/__tests__/SearchResultsList.jest.tsx
@@ -1,0 +1,171 @@
+import { ActionType, ContextModule } from "@artsy/cohesion"
+import { render, screen } from "@testing-library/react"
+import { useFlag } from "@unleash/proxy-client-react"
+import { SearchResultsList } from "Components/Search/Mobile/SearchResultsList"
+import { ARTWORKS_PILL, TOP_PILL } from "Components/Search/constants"
+import type { SearchResultsList_viewer$data } from "__generated__/SearchResultsList_viewer.graphql"
+import type { RelayPaginationProp } from "react-relay"
+import { useTracking } from "react-tracking"
+
+jest.mock("@unleash/proxy-client-react", () => ({ useFlag: jest.fn() }))
+jest.mock("react-tracking")
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: () => {
+    return { router: { push: jest.fn() }, match: { location: {} } }
+  },
+}))
+
+const mockTrackEvent = jest.fn()
+const mockOnClose = jest.fn()
+
+const QUERY = "warhol prints under 5000"
+
+const relay = {
+  hasMore: () => false,
+  isLoading: () => false,
+  loadMore: jest.fn(),
+} as unknown as RelayPaginationProp
+
+const viewerWithNoResults = {
+  searchConnection: { edges: [] },
+} as unknown as SearchResultsList_viewer$data
+
+// The default: the row has to sit above real entity results, not only in the
+// empty state
+const viewerWithResults = {
+  searchConnection: {
+    edges: [
+      {
+        highlights: null,
+        node: {
+          __typename: "SearchableItem",
+          displayLabel: "Andy Warhol",
+          displayType: "Artist",
+          href: "/artist/andy-warhol",
+          imageUrl: "",
+          internalID: "andy-warhol-id",
+          slug: "andy-warhol",
+        },
+      },
+    ],
+  },
+} as unknown as SearchResultsList_viewer$data
+
+const renderList = ({
+  query = QUERY,
+  selectedPill = TOP_PILL,
+  viewer = viewerWithResults,
+} = {}) => {
+  return render(
+    <SearchResultsList
+      relay={relay}
+      viewer={viewer}
+      query={query}
+      debouncedQuery={query}
+      selectedPill={selectedPill}
+      onClose={mockOnClose}
+    />,
+  )
+}
+
+const row = () => {
+  return screen.queryByTestId("suggestedFiltersRow")
+}
+
+describe("SearchResultsList", () => {
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return { trackEvent: mockTrackEvent }
+    })
+    ;(useFlag as jest.Mock).mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("suggested filters row", () => {
+    it("links to the term page with the parsed filters", () => {
+      renderList()
+
+      // First of several links: prepended above the entity results
+      const links = screen.getAllByRole("link")
+      expect(links.length).toBeGreaterThan(1)
+      expect(links[0]).toHaveAttribute("data-testid", "suggestedFiltersRow")
+
+      expect(row()).toHaveTextContent("warhol")
+      expect(row()).toHaveTextContent("in Prints · Under $5,000")
+
+      const href = row()?.getAttribute("href")
+      expect(href).toContain("/search?")
+      expect(href).toContain("term=warhol&")
+      expect(href).toContain("additional_gene_ids%5B0%5D=prints")
+    })
+
+    it("is hidden when the feature flag is off", () => {
+      ;(useFlag as jest.Mock).mockImplementation(() => false)
+      renderList()
+
+      expect(row()).not.toBeInTheDocument()
+    })
+
+    it("is hidden when the query parses to no filters", () => {
+      renderList({ query: "warhol" })
+
+      expect(row()).not.toBeInTheDocument()
+    })
+
+    it("is hidden on the entity pills, which scope to a single type", () => {
+      renderList({ selectedPill: ARTWORKS_PILL })
+
+      expect(row()).not.toBeInTheDocument()
+    })
+
+    it("still shows when nothing else matched", () => {
+      // With no entity result, the filters are the only answer left
+      renderList({ viewer: viewerWithNoResults })
+
+      expect(screen.getByText(/we couldn’t find anything/)).toBeInTheDocument()
+      expect(row()).toBeInTheDocument()
+    })
+
+    it("tracks its impression once", () => {
+      const { rerender } = renderList()
+
+      rerender(
+        <SearchResultsList
+          relay={relay}
+          viewer={viewerWithResults}
+          query={QUERY}
+          debouncedQuery={QUERY}
+          selectedPill={TOP_PILL}
+          onClose={mockOnClose}
+        />,
+      )
+
+      const railViewed = mockTrackEvent.mock.calls.filter(([event]) => {
+        return event.action === ActionType.railViewed
+      })
+
+      expect(railViewed).toHaveLength(1)
+      expect(railViewed[0][0]).toMatchObject({
+        context_module: ContextModule.suggestedFilters,
+      })
+    })
+
+    it("tracks its own context module on click, and closes the overlay", () => {
+      renderList()
+      row()?.click()
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: ActionType.selectedItemFromSearch,
+          context_module: ContextModule.suggestedFilters,
+          item_id: "suggested-filters",
+          item_type: "filter-suggestion",
+        }),
+      )
+      expect(mockOnClose).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Renders the suggested filters row in the mobile search overlay and the filter pills for mobile web.

<img width="500" height="688" alt="Screenshot 2026-09-02 at 14 29 23" src="https://github.com/user-attachments/assets/f9dcfc90-74c7-48cc-8f0a-298eff3feda0" />
<img width="500" height="832" alt="Screenshot 2026-09-02 at 14 29 46" src="https://github.com/user-attachments/assets/f52682c1-2dff-4e3b-970a-b3bc80e71abe" />
