### PR TITLE
feat(suggested-search): read artist nationality from query

### DIFF
--- a/src/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
+++ b/src/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
@@ -2,12 +2,14 @@ import type { Aggregations } from "Components/ArtworkFilter/ArtworkFilterContext
 import {
   excludeDefaultCriteria,
   extractPillFromAggregation,
+  extractPillsFromCriteria,
   extractPillsFromDefaultCriteria,
 } from "Components/SavedSearchAlert/Utils/extractPills"
 import type {
   SavedSearchDefaultCriteria,
   SearchCriteriaAttributes,
 } from "Components/SavedSearchAlert/types"
+import { DEFAULT_METRIC } from "Utils/metrics"
 
 describe("extractPillFromAggregation", () => {
   it("returns pills", () => {
@@ -61,6 +63,30 @@ describe("extractPillFromAggregation", () => {
       },
       { displayValue: "NFT", value: "nft", field: "additionalGeneIDs" },
     ])
+  })
+})
+
+describe("extractPillsFromCriteria", () => {
+  // Without a pill the keyword only shows as a count on "All Filters", so
+  // there is nothing naming it and nothing to untick
+  it("names an applied keyword", () => {
+    const result = extractPillsFromCriteria({
+      criteria: { keyword: "warhol" },
+      metric: DEFAULT_METRIC,
+    })
+
+    expect(result).toEqual([
+      { field: "keyword", value: "warhol", displayValue: "warhol" },
+    ])
+  })
+
+  it("omits an empty keyword", () => {
+    const result = extractPillsFromCriteria({
+      criteria: { keyword: "" },
+      metric: DEFAULT_METRIC,
+    })
+
+    expect(result).toEqual([])
   })
 })
 

--- a/src/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -113,6 +113,16 @@ export const extractPillsFromCriteria = ({
     }
 
     switch (paramName) {
+      case "keyword": {
+        if (paramValue) {
+          result = {
+            field: paramName,
+            value: String(paramValue),
+            displayValue: String(paramValue),
+          }
+        }
+        break
+      }
       case "width":
       case "height": {
         if (paramValue && isCustomValue(paramValue)) {

--- a/src/Components/SavedSearchAlert/types.ts
+++ b/src/Components/SavedSearchAlert/types.ts
@@ -14,6 +14,7 @@ export interface SearchCriteriaAttributes {
   framed?: boolean | null
   height?: string | null
   inquireableOnly?: boolean | null
+  keyword?: string | null
   locationCities?: string[] | null
   majorPeriods?: string[] | null
   materialsTerms?: string[] | null

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -51,6 +51,7 @@ import { getLabel } from "./utils/getLabel"
 import { isModifiedClick } from "./utils/isModifiedClick"
 import { buildSuggestedFiltersUrl } from "./utils/buildSuggestedFiltersUrl"
 import { parseFilterQuery } from "./utils/parseFilterQuery"
+import { shouldSubmitToFilters } from "./utils/shouldSubmitToFilters"
 import { searchResultsHref } from "./utils/searchResultsHref"
 import { shouldStartSearching } from "./utils/shouldStartSearching"
 
@@ -128,20 +129,10 @@ export const SearchBarInput: FC<
   const formattedOptions: SuggestionItemOptionProps[] = [
     ...(shouldShowSuggestedFilters
       ? [
-          {
-            kind: "suggestedFilters" as const,
-            text: value,
-            value: value,
-            subtitle: "",
-            imageUrl: "",
-            showAuctionResultsButton: false,
+          buildSuggestedFiltersOption({
+            query: value,
             href: suggestedFiltersHref,
-            typename: "SuggestedFilters",
-            item_id: "suggested-filters",
-            // Position within its own context module, not the entity ranking
-            item_number: 0,
-            item_type: "filter-suggestion",
-          },
+          }),
         ]
       : []),
     ...edges.flatMap((edge, index) => {
@@ -295,9 +286,27 @@ export const SearchBarInput: FC<
     const term = value.trim()
     if (!term) return
 
-    addRecentSearch({ label: term, href: encodedSearchURL })
+    // The row renders off the debounced value, so submitting before it appears
+    // would send the whole query as a keyword and return nothing. Parsing the
+    // live term keeps Enter on the destination the row points at, but only for
+    // the queries `shouldSubmitToFilters` trusts — the rest stay a search.
+    const candidate =
+      isSuggestedFiltersEnabled && selectedPill === TOP_PILL
+        ? parseFilterQuery(term)
+        : null
+
+    const parsed =
+      candidate && shouldSubmitToFilters(candidate) ? candidate : null
+
+    const href = parsed ? buildSuggestedFiltersUrl(parsed) : encodedSearchURL
+
+    if (parsed) {
+      trackSelection(buildSuggestedFiltersOption({ query: term, href }))
+    }
+
+    addRecentSearch({ label: term, href })
     closeDropdown()
-    redirect(encodedSearchURL)
+    redirect(href)
   }
 
   const trackSelection = (option: SuggestionItemOptionProps) => {
@@ -573,6 +582,31 @@ export const SearchBarInput: FC<
       </Box>
     </ManageArtworkForSavesProvider>
   )
+}
+
+// Shared by the dropdown row and the Enter submit, so both record the same
+// selection against the suggested-filters module
+const buildSuggestedFiltersOption = ({
+  query,
+  href,
+}: {
+  query: string
+  href: string
+}): SuggestionItemOptionProps => {
+  return {
+    kind: "suggestedFilters" as const,
+    text: query,
+    value: query,
+    subtitle: "",
+    imageUrl: "",
+    showAuctionResultsButton: false,
+    href,
+    typename: "SuggestedFilters",
+    item_id: "suggested-filters",
+    // Position within its own context module, not the entity ranking
+    item_number: 0,
+    item_type: "filter-suggestion",
+  }
 }
 
 // Same box shadow as Palette's AutocompleteInput dropdown, so the trending

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -659,5 +659,93 @@ describe("SearchBarInput", () => {
         expect.objectContaining({ action: ActionType.railViewed }),
       )
     })
+
+    describe("submitting with Enter", () => {
+      // The row renders off the debounced value, so Enter has to parse the
+      // live term or the whole query goes out as a keyword and returns nothing
+      const submit = async () => {
+        await userEvent.type(screen.getByRole("textbox"), "{Enter}")
+      }
+
+      it("navigates to the filtered page rather than the raw term", async () => {
+        enableSuggestedFilters()
+        render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+        await submit()
+
+        expect(mockPush).toHaveBeenCalledWith(
+          expect.stringContaining("additional_gene_ids"),
+        )
+        expect(mockPush).not.toHaveBeenCalledWith(
+          "/search?term=warhol%20prints%20under%205000",
+        )
+      })
+
+      it("records the filtered page as the recent search", async () => {
+        enableSuggestedFilters()
+        render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+        await submit()
+
+        const [recent] = JSON.parse(
+          localStorage.getItem("artsy.recentSearches")!,
+        )
+
+        expect(recent.label).toEqual("warhol prints under 5000")
+        expect(recent.href).toContain("additional_gene_ids")
+      })
+
+      it("tracks the submit under the suggested filters module", async () => {
+        enableSuggestedFilters()
+        render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+        await submit()
+
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: ActionType.selectedItemFromSearch,
+            context_module: ContextModule.suggestedFilters,
+            item_id: "suggested-filters",
+          }),
+        )
+      })
+
+      it("falls back to the raw term when the query does not parse", async () => {
+        enableSuggestedFilters()
+        render(<SearchBarInput searchTerm="andy" />)
+
+        await submit()
+
+        expect(mockPush).toHaveBeenCalledWith("/search?term=andy")
+      })
+
+      it("leaves a name-shaped query as a plain search", async () => {
+        // "paris photo" is a fair: one medium beside free text is the shape
+        // entity names take, and the raw term already finds them
+        enableSuggestedFilters()
+        render(<SearchBarInput searchTerm="paris photo" />)
+
+        await submit()
+
+        expect(mockPush).toHaveBeenCalledWith("/search?term=paris%20photo")
+      })
+
+      it("still offers the row for a query it will not submit to", () => {
+        enableSuggestedFilters()
+        render(<SearchBarInput searchTerm="paris photo" />)
+
+        expect(row()).toBeInTheDocument()
+      })
+
+      it("leaves the raw term alone when the feature flag is off", async () => {
+        render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+        await submit()
+
+        expect(mockPush).toHaveBeenCalledWith(
+          "/search?term=warhol%20prints%20under%205000",
+        )
+      })
+    })
   })
 })

--- a/src/Components/Search/__tests__/SuggestedFiltersItem.jest.tsx
+++ b/src/Components/Search/__tests__/SuggestedFiltersItem.jest.tsx
@@ -20,7 +20,7 @@ describe("SuggestedFiltersItem", () => {
   })
 
   const parsed = (keyword: string, labels: string[]): ParsedFilterQuery => {
-    return { filters: {}, keyword, labels }
+    return { filters: {}, keyword, labels, termLabel: labels[0] }
   }
 
   const renderRow = ({

--- a/src/Components/Search/utils/__tests__/buildSuggestedFiltersUrl.jest.ts
+++ b/src/Components/Search/utils/__tests__/buildSuggestedFiltersUrl.jest.ts
@@ -64,4 +64,24 @@ describe("buildSuggestedFiltersUrl", () => {
     expect(url).not.toContain("between")
     expect(url).not.toContain("1k")
   })
+
+  it("sends one param per nationality the demonym stands for", () => {
+    const url = urlFor("korean paintings under 5k")
+
+    expect(url).toContain("artist_nationalities[0]=Korean")
+    expect(url).toContain("artist_nationalities[1]=South Korean")
+  })
+
+  it("never stands the nationality in as the term", () => {
+    const url = urlFor("chinese photography")
+
+    expect(url).toContain("term=Photography&")
+    expect(url).toContain("artist_nationalities[0]=Chinese")
+  })
+
+  it("omits nationalities the query didn't ask for", () => {
+    expect(urlFor("warhol prints under 5000")).not.toContain(
+      "artist_nationalities",
+    )
+  })
 })

--- a/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
+++ b/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
@@ -277,6 +277,31 @@ describe("parseFilterQuery", () => {
     })
   })
 
+  describe("only stands a medium in as the search term", () => {
+    // The term doubles as the artworks keyword, so a rarity standing in costs
+    // almost every result the filters were meant to return: "unique under 5k"
+    // returns 628 against ~838,000 for the same filters alone
+    it.each(["unique under 5k", "limited edition under 10k"])(
+      "returns null for %p",
+      query => {
+        expect(parseFilterQuery(query)).toBeNull()
+      },
+    )
+
+    it("still suggests a rarity when free text carries the term", () => {
+      const result = parseFilterQuery("banksy limited edition under 10k")
+
+      expect(result?.filters.attributionClass).toEqual(["limited edition"])
+      expect(result?.keyword).toEqual("banksy")
+    })
+
+    it("stands the medium in ahead of the rarity", () => {
+      expect(parseFilterQuery("unique prints under 5k")?.termLabel).toEqual(
+        "Prints",
+      )
+    })
+  })
+
   describe("does not read a nationality out of a movement or a material", () => {
     it.each([
       ["african american photography", "photography", "african american"],

--- a/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
+++ b/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
@@ -216,6 +216,128 @@ describe("parseFilterQuery", () => {
     })
   })
 
+  describe("artist nationality", () => {
+    it("reads a nationality alongside a medium", () => {
+      const result = parseFilterQuery("chinese photography")
+
+      expect(result?.filters.artistNationalities).toEqual(["Chinese"])
+      expect(result?.filters.medium).toEqual("photography")
+      expect(result?.labels).toEqual(["Chinese", "Photography"])
+    })
+
+    it("sends every value a demonym the aggregation splits stands for", () => {
+      const result = parseFilterQuery("korean paintings under 5k")
+
+      expect(result?.filters.artistNationalities).toEqual([
+        "Korean",
+        "South Korean",
+      ])
+      expect(result?.filters.medium).toEqual("painting")
+      expect(result?.filters.priceRange).toEqual("*-5000")
+    })
+
+    it("names the nationality ahead of the other filters", () => {
+      expect(parseFilterQuery("chinese prints under 5k")?.labels).toEqual([
+        "Chinese",
+        "Prints",
+        "Under $5,000",
+      ])
+    })
+
+    it.each([
+      ["south korean prints", "Korean"],
+      ["argentinian prints", "Argentine"],
+      ["filipino prints", "Philippine"],
+      ["slovenian prints", "Slovene"],
+    ])("resolves %p to the aggregation's own %p", (query, label) => {
+      expect(parseFilterQuery(query)?.labels).toContain(label)
+    })
+
+    it("does not invert a negated nationality", () => {
+      expect(parseFilterQuery("prints not chinese")).toBeNull()
+    })
+  })
+
+  describe("only trusts a nationality another filter backs up", () => {
+    // Demonyms turn up in titles, artist names and subject matter far more
+    // often than they state a nationality
+    it.each([
+      ["chinese", "a bare demonym"],
+      ["chinese ceramics", "free text the parser cannot name a filter from"],
+      ["american warhol", "an artist name"],
+      ["jack dowling (american, 1931-2021)", "artist life dates (production)"],
+    ])("returns null for %p — %s", query => {
+      expect(parseFilterQuery(query)).toBeNull()
+    })
+
+    it("does not let a price alone back a nationality", () => {
+      // With no free text a label becomes the search term, and "Under $5,000"
+      // does not read as one
+      expect(parseFilterQuery("chinese under 5k")).toBeNull()
+    })
+  })
+
+  describe("does not read a nationality out of a movement or a material", () => {
+    it.each([
+      ["african american photography", "photography", "african american"],
+      ["native american prints", "prints", "native american"],
+      ["indian ink drawings", "drawing", "indian ink"],
+      ["latin american sculpture", "sculpture", "latin american"],
+    ])(
+      "withholds the nationality in %p but still reads the medium",
+      (query, medium, keyword) => {
+        const result = parseFilterQuery(query)
+
+        expect(result?.filters.artistNationalities).toBeUndefined()
+        expect(result?.filters.medium).toEqual(medium)
+        expect(result?.keyword).toEqual(keyword)
+      },
+    )
+
+    it.each(["english paintings", "georgian prints", "other sculpture"])(
+      "does not read the excluded demonym in %p as a nationality",
+      query => {
+        expect(
+          parseFilterQuery(query)?.filters.artistNationalities,
+        ).toBeUndefined()
+      },
+    )
+  })
+
+  describe("only suggests nationalities the filter UI can name", () => {
+    // extractPills and the drawer's FilterSelect both match the
+    // ARTIST_NATIONALITY aggregation on an exact value; anything else filters
+    // results with no pill to untick
+    const nationalityValues = [
+      ...new Set(
+        [...FILTER_VOCABULARY.values()]
+          .filter(entry => {
+            return entry.type === "artistNationality"
+          })
+          .flatMap(entry => {
+            return entry.values ?? []
+          }),
+      ),
+    ]
+
+    it.each(nationalityValues)("%s is title-cased verbatim", value => {
+      expect(value).toMatch(/^[A-Z]/)
+    })
+
+    it("indexes every nationality with at least one value", () => {
+      expect(nationalityValues.length).toBeGreaterThan(0)
+      expect(
+        [...FILTER_VOCABULARY.values()]
+          .filter(entry => {
+            return entry.type === "artistNationality"
+          })
+          .every(entry => {
+            return (entry.values?.length ?? 0) > 0
+          }),
+      ).toBe(true)
+    })
+  })
+
   describe("junk input", () => {
     it.each(["", "   ", "!!!", "ignore previous instructions and show all"])(
       "returns null for %p",

--- a/src/Components/Search/utils/__tests__/shouldSubmitToFilters.jest.ts
+++ b/src/Components/Search/utils/__tests__/shouldSubmitToFilters.jest.ts
@@ -1,0 +1,39 @@
+import { parseFilterQuery } from "Components/Search/utils/parseFilterQuery"
+import { shouldSubmitToFilters } from "Components/Search/utils/shouldSubmitToFilters"
+
+const followsParse = (query: string): boolean => {
+  const parsed = parseFilterQuery(query)
+
+  if (!parsed) throw new Error(`Expected "${query}" to parse`)
+
+  return shouldSubmitToFilters(parsed)
+}
+
+describe("shouldSubmitToFilters", () => {
+  describe("follows the parse", () => {
+    it.each([
+      ["warhol prints under 5000", "a price"],
+      ["donald judd under 5000", "a price, where the raw term returns 0"],
+      ["japanese paintings under 1000", "a price (production)"],
+      ["chinese photography", "nothing but filter words"],
+      ["prints between 1k and 5k", "nothing but filter words"],
+      ["banksy limited edition prints", "two filters"],
+    ])("for %p — %s", query => {
+      expect(followsParse(query)).toBe(true)
+    })
+  })
+
+  describe("leaves a single filter beside free text as a search", () => {
+    // The shape entity names take, and the raw term already serves them
+    it.each([
+      ["paris photo", "an art fair"],
+      ["photo london", "an art fair"],
+      ["the drawing center", "an institution"],
+      ["sculpture center", "an institution"],
+      ["unique forms of continuity in space", "an artwork title"],
+      ["warhol prints", "an artist plus a medium"],
+    ])("for %p — %s", query => {
+      expect(followsParse(query)).toBe(false)
+    })
+  })
+})

--- a/src/Components/Search/utils/buildSuggestedFiltersUrl.ts
+++ b/src/Components/Search/utils/buildSuggestedFiltersUrl.ts
@@ -13,22 +13,13 @@ export const buildSuggestedFiltersUrl = (parsed: ParsedFilterQuery): string => {
   const { medium, priceRange, attributionClass, artistNationalities } =
     parsed.filters
 
-  // Every nationality label is the first of the values it stands for, so this
-  // leaves the labels the term can safely repeat
-  const nationalityLabels = new Set(artistNationalities ?? [])
-  const standInLabel = parsed.labels.find(label => {
-    return !nationalityLabels.has(label)
-  })
-
   const params = {
     // Free text only: the term doubles as the artworks keyword, and searching
     // the filter words too returns nothing ("warhol prints under 5000" -> 0,
-    // "warhol" plus the same filters -> ~1,500). With no free text a label
-    // stands in, keeping the heading readable — never the nationality, whose
-    // keyword costs far more than it names ("chinese photography" -> 63,
-    // the same filters alone -> ~3,800). A row always carries a keyword or a
-    // non-nationality filter, so there is deliberately no raw-query fallback.
-    term: parsed.keyword || standInLabel || parsed.labels[0],
+    // "warhol" plus the same filters -> ~1,500). With no free text `termLabel`
+    // stands in, keeping the heading readable. A row always carries one or the
+    // other, so there is deliberately no raw-query fallback here.
+    term: parsed.keyword || parsed.termLabel,
     additionalGeneIDs: medium ? [medium] : undefined,
     attributionClass,
     artistNationalities,

--- a/src/Components/Search/utils/buildSuggestedFiltersUrl.ts
+++ b/src/Components/Search/utils/buildSuggestedFiltersUrl.ts
@@ -10,17 +10,28 @@ import type { ParsedFilterQuery } from "./parseFilterQuery"
  * page's Medium filter reads, so the pill shows as applied.
  */
 export const buildSuggestedFiltersUrl = (parsed: ParsedFilterQuery): string => {
-  const { medium, priceRange, attributionClass } = parsed.filters
+  const { medium, priceRange, attributionClass, artistNationalities } =
+    parsed.filters
+
+  // Every nationality label is the first of the values it stands for, so this
+  // leaves the labels the term can safely repeat
+  const nationalityLabels = new Set(artistNationalities ?? [])
+  const standInLabel = parsed.labels.find(label => {
+    return !nationalityLabels.has(label)
+  })
 
   const params = {
     // Free text only: the term doubles as the artworks keyword, and searching
     // the filter words too returns nothing ("warhol prints under 5000" -> 0,
-    // "warhol" plus the same filters -> ~1,500). With no free text the leading
-    // label stands in, keeping the heading readable. A row always carries one
-    // or the other, so there is deliberately no raw-query fallback here.
-    term: parsed.keyword || parsed.labels[0],
+    // "warhol" plus the same filters -> ~1,500). With no free text a label
+    // stands in, keeping the heading readable — never the nationality, whose
+    // keyword costs far more than it names ("chinese photography" -> 63,
+    // the same filters alone -> ~3,800). A row always carries a keyword or a
+    // non-nationality filter, so there is deliberately no raw-query fallback.
+    term: parsed.keyword || standInLabel || parsed.labels[0],
     additionalGeneIDs: medium ? [medium] : undefined,
     attributionClass,
+    artistNationalities,
     priceRange,
   }
 

--- a/src/Components/Search/utils/filterQueryVocabulary.ts
+++ b/src/Components/Search/utils/filterQueryVocabulary.ts
@@ -2,12 +2,14 @@ import { FILTER_CATEGORIES } from "Apps/Artwork/Utils/createCollectUrl"
 import { ATTRIBUTION_CLASS_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
 import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 
-export type VocabularyType = "medium" | "attributionClass"
+export type VocabularyType = "medium" | "attributionClass" | "artistNationality"
 
 export interface VocabularyEntry {
   type: VocabularyType
   /** The value written into ArtworkFilters, e.g. "prints" / "limited edition" */
   value: string
+  /** Nationalities only: every aggregation value the demonym stands for */
+  values?: string[]
   /** The label shown in the suggestion row, e.g. "Prints" */
   label: string
 }
@@ -53,6 +55,116 @@ const ATTRIBUTION_ALIASES: Record<string, string> = {
   "limited editions": "limited edition",
   "open-edition": "open edition",
   "open editions": "open edition",
+}
+
+/**
+ * Verbatim `ARTIST_NATIONALITY` aggregation values — a value the aggregation
+ * doesn't carry applies a filter that no pill can name and no checkbox can
+ * untick. Demonyms that are also languages, periods or place names ("English",
+ * "Georgian", "Catalan", "Hong Kong", "New Zealand") are left out, as is the
+ * catch-all "Other" and the hyphenated composites ("Chinese-American").
+ */
+const NATIONALITIES = [
+  "Algerian",
+  "American",
+  "Angolan",
+  "Argentine",
+  "Armenian",
+  "Australian",
+  "Austrian",
+  "Bahamian",
+  "Belgian",
+  "Beninese",
+  "Bolivian",
+  "Bosnian",
+  "Brazilian",
+  "British",
+  "Cameroonian",
+  "Canadian",
+  "Chilean",
+  "Chinese",
+  "Colombian",
+  "Congolese",
+  "Croatian",
+  "Cuban",
+  "Czech",
+  "Danish",
+  "Dominican",
+  "Dutch",
+  "Ecuadorian",
+  "Egyptian",
+  "Estonian",
+  "Finnish",
+  "French",
+  "German",
+  "Ghanaian",
+  "Greek",
+  "Guatemalan",
+  "Hungarian",
+  "Icelandic",
+  "Indian",
+  "Indonesian",
+  "Iranian",
+  "Iraqi",
+  "Irish",
+  "Israeli",
+  "Italian",
+  "Ivorian",
+  "Japanese",
+  "Kenyan",
+  "Korean",
+  "Latvian",
+  "Lebanese",
+  "Lithuanian",
+  "Malaysian",
+  "Malian",
+  "Mexican",
+  "Moroccan",
+  "Mozambican",
+  "Nigerian",
+  "Norwegian",
+  "Pakistani",
+  "Palestinian",
+  "Peruvian",
+  "Philippine",
+  "Polish",
+  "Portuguese",
+  "Puerto Rican",
+  "Romanian",
+  "Russian",
+  "Scottish",
+  "Senegalese",
+  "Serbian",
+  "Singaporean",
+  "Slovak",
+  "Slovene",
+  "South African",
+  "Spanish",
+  "Swedish",
+  "Swiss",
+  "Syrian",
+  "Taiwanese",
+  "Thai",
+  "Tunisian",
+  "Turkish",
+  "Ukrainian",
+  "Uruguayan",
+  "Venezuelan",
+  "Vietnamese",
+  "Welsh",
+  "Zimbabwean",
+]
+
+/** Demonyms the aggregation keeps split across more than one value */
+const NATIONALITY_GROUPS: Record<string, string[]> = {
+  Korean: ["Korean", "South Korean"],
+}
+
+const NATIONALITY_ALIASES: Record<string, string> = {
+  argentinian: "Argentine",
+  filipino: "Philippine",
+  slovenian: "Slovene",
+  "south korean": "Korean",
 }
 
 /**
@@ -112,6 +224,19 @@ export const COLLISION_PHRASES = [
   "the painting of modern life",
 ]
 
+/**
+ * Phrases where a demonym names a movement, a material or a title rather than
+ * an artist's nationality. Only the nationality is withheld — "african
+ * american photography" still parses as Photography.
+ */
+export const NATIONALITY_COLLISION_PHRASES = [
+  "african american",
+  "american gothic",
+  "indian ink",
+  "latin american",
+  "native american",
+]
+
 export const normalizePhrase = (phrase: string): string => {
   return phrase.toLowerCase().replace(/\s+/g, " ").trim()
 }
@@ -169,6 +294,15 @@ const buildVocabulary = (): Map<string, VocabularyEntry> => {
     add(deslugify(value), entry)
   })
 
+  NATIONALITIES.forEach(nationality => {
+    add(nationality, {
+      type: "artistNationality",
+      value: nationality,
+      values: NATIONALITY_GROUPS[nationality] ?? [nationality],
+      label: nationality,
+    })
+  })
+
   ATTRIBUTION_CLASS_OPTIONS.forEach(({ name, value }) => {
     const entry: VocabularyEntry = {
       type: "attributionClass",
@@ -195,6 +329,7 @@ const buildVocabulary = (): Map<string, VocabularyEntry> => {
 
   addAliases(MEDIUM_ALIASES)
   addAliases(ATTRIBUTION_ALIASES)
+  addAliases(NATIONALITY_ALIASES)
 
   return vocabulary
 }

--- a/src/Components/Search/utils/parseFilterQuery.ts
+++ b/src/Components/Search/utils/parseFilterQuery.ts
@@ -4,6 +4,7 @@ import {
   COLLISION_PHRASES,
   FILTER_VOCABULARY,
   MAX_PHRASE_WORDS,
+  NATIONALITY_COLLISION_PHRASES,
   NEGATORS,
   STOPWORDS,
   type VocabularyEntry,
@@ -17,14 +18,18 @@ import {
  */
 export type SuggestedFilters = Pick<
   ArtworkFilters,
-  "medium" | "priceRange" | "attributionClass" | "keyword"
+  | "medium"
+  | "priceRange"
+  | "attributionClass"
+  | "artistNationalities"
+  | "keyword"
 >
 
 export interface ParsedFilterQuery {
   filters: SuggestedFilters
   /** Everything the parser didn't consume; goes into the keyword filter */
   keyword: string
-  /** Human labels in display order: medium, rarity, price */
+  /** Human labels in display order: nationality, medium, rarity, price */
   labels: string[]
 }
 
@@ -190,7 +195,19 @@ interface PhraseAccumulator {
   hasNegatedMatch: boolean
 }
 
-const extractVocabulary = (tokens: string[]): PhraseAccumulator => {
+const extractVocabulary = ({
+  tokens,
+  allowNationality,
+}: {
+  tokens: string[]
+  allowNationality: boolean
+}): PhraseAccumulator => {
+  const isUsable = (entry: VocabularyEntry | undefined): boolean => {
+    if (!entry) return false
+
+    return allowNationality || entry.type !== "artistNationality"
+  }
+
   return tokens.reduce<PhraseAccumulator>(
     (acc, _token, index) => {
       if (index < acc.skipUntil) return acc
@@ -209,7 +226,7 @@ const extractVocabulary = (tokens: string[]): PhraseAccumulator => {
           return { size, entry: FILTER_VOCABULARY.get(phrase) }
         })
         .find(({ entry }) => {
-          return !!entry
+          return isUsable(entry)
         })
 
       if (!hit?.entry) {
@@ -284,7 +301,12 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
   const { priceRange, rest } = extractPrice(clean(query))
 
   const tokens = rest.split(/\s+/).filter(Boolean)
-  const { matches, leftover, hasNegatedMatch } = extractVocabulary(tokens)
+  const { matches, leftover, hasNegatedMatch } = extractVocabulary({
+    tokens,
+    allowNationality: !NATIONALITY_COLLISION_PHRASES.some(phrase => {
+      return normalizedQuery.includes(phrase)
+    }),
+  })
 
   // Only positive filters are expressible, so an exclusion can't be honoured —
   // and filtering *to* the excluded value is worse than staying quiet
@@ -309,6 +331,24 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
 
   const medium = mediumEntries[0]
 
+  const nationalityEntries = matches.filter(entry => {
+    return entry.type === "artistNationality"
+  })
+  const nationalityLabels = [
+    ...new Set(
+      nationalityEntries.map(entry => {
+        return entry.label
+      }),
+    ),
+  ]
+  const artistNationalities = [
+    ...new Set(
+      nationalityEntries.flatMap(entry => {
+        return entry.values ?? [entry.value]
+      }),
+    ),
+  ]
+
   const attributionEntries = matches.filter(entry => {
     return entry.type === "attributionClass"
   })
@@ -329,9 +369,19 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
   const filterCount =
     (medium ? 1 : 0) + (priceRange ? 1 : 0) + attributionClass.length
 
-  if (!shouldSuggestFilters({ filterCount, keyword })) return null
+  if (
+    !shouldSuggestFilters({
+      filterCount,
+      nationalityCount: nationalityLabels.length,
+      hasNameableFilter: !!medium || attributionClass.length > 0,
+      keyword,
+    })
+  ) {
+    return null
+  }
 
   const labels = [
+    ...nationalityLabels,
     medium?.label,
     ...attributionEntries.map(entry => entry.label),
     priceRange ? formatPriceRangeLabel(priceRange) : undefined,
@@ -342,6 +392,9 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
       medium: medium?.value,
       priceRange,
       attributionClass: attributionClass.length ? attributionClass : undefined,
+      artistNationalities: artistNationalities.length
+        ? artistNationalities
+        : undefined,
       keyword: keyword || undefined,
     },
     keyword,
@@ -353,15 +406,28 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
  * A single recognized filter with no keyword ("prints") is better served by the
  * gene/collection entity the backend already returns, so hold the row back
  * until there's either free text to carry over or a second filter.
+ *
+ * A nationality never counts as that filter on its own: demonyms turn up
+ * inside titles, artist names and subject matter far more often than they
+ * state an artist's nationality, so one has to arrive alongside a medium,
+ * rarity or price to be trusted.
  */
 const shouldSuggestFilters = ({
   filterCount,
+  nationalityCount,
+  hasNameableFilter,
   keyword,
 }: {
   filterCount: number
+  nationalityCount: number
+  hasNameableFilter: boolean
   keyword: string
 }): boolean => {
   if (filterCount === 0) return false
 
-  return keyword.length > 0 || filterCount >= 2
+  if (keyword.length > 0) return true
+
+  // With no free text a filter label becomes the search term, and a price
+  // doesn't read as one
+  return hasNameableFilter && filterCount + nationalityCount >= 2
 }

--- a/src/Components/Search/utils/parseFilterQuery.ts
+++ b/src/Components/Search/utils/parseFilterQuery.ts
@@ -31,6 +31,12 @@ export interface ParsedFilterQuery {
   keyword: string
   /** Human labels in display order: nationality, medium, rarity, price */
   labels: string[]
+  /**
+   * Stands in as the search term when there is no free text. The medium is the
+   * only label that reads as one: a rarity or a nationality repeated as a
+   * keyword throws away most of the results the filters already cover.
+   */
+  termLabel: string
 }
 
 interface PricePattern {
@@ -373,7 +379,7 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
     !shouldSuggestFilters({
       filterCount,
       nationalityCount: nationalityLabels.length,
-      hasNameableFilter: !!medium || attributionClass.length > 0,
+      hasMedium: !!medium,
       keyword,
     })
   ) {
@@ -399,6 +405,7 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
     },
     keyword,
     labels,
+    termLabel: medium?.label ?? labels[0],
   }
 }
 
@@ -415,19 +422,20 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
 const shouldSuggestFilters = ({
   filterCount,
   nationalityCount,
-  hasNameableFilter,
+  hasMedium,
   keyword,
 }: {
   filterCount: number
   nationalityCount: number
-  hasNameableFilter: boolean
+  hasMedium: boolean
   keyword: string
 }): boolean => {
   if (filterCount === 0) return false
 
   if (keyword.length > 0) return true
 
-  // With no free text a filter label becomes the search term, and a price
-  // doesn't read as one
-  return hasNameableFilter && filterCount + nationalityCount >= 2
+  // With no free text the medium becomes the search term. Standing a rarity in
+  // instead costs almost every result the filters were meant to return
+  // ("unique under 5k" -> 628, the same filters alone -> ~838,000).
+  return hasMedium && filterCount + nationalityCount >= 2
 }

--- a/src/Components/Search/utils/shouldSubmitToFilters.ts
+++ b/src/Components/Search/utils/shouldSubmitToFilters.ts
@@ -1,0 +1,22 @@
+import type { ParsedFilterQuery } from "./parseFilterQuery"
+
+/**
+ * Whether a plain Enter should follow the parse instead of searching the raw
+ * term.
+ *
+ * A single medium or rarity beside free text is the shape entity names take —
+ * "paris photo", "the drawing center", "unique forms of continuity in space" —
+ * and the raw term already serves those well ("warhol prints" -> ~8,200,
+ * "paris photo" -> ~18,700). A price, a second filter, or a query that is
+ * nothing but filter words doesn't read as a name, and there the raw term
+ * returns nothing at all ("donald judd under 5000" -> 0).
+ *
+ * The row stays in the dropdown either way, so a narrower parse is still one
+ * click away.
+ */
+export const shouldSubmitToFilters = (parsed: ParsedFilterQuery): boolean => {
+  if (!parsed.keyword) return true
+  if (parsed.filters.priceRange) return true
+
+  return parsed.labels.length >= 2
+}


### PR DESCRIPTION
Suggested filters can now read an artist nationality out of a search query, using **demonyms** hardcoded with the exact casing the `ARTIST_NATIONALITY` aggregation returns. It is deliberately strict for now: a nationality only fires when a medium or rarity backs it up, so we stay away from queries where a demonym isn’t actually about the artist.

### Example queries

| Query | Result |
| --- | --- |
| `chinese photography` | Chinese · Photography |
| `korean paintings under 5k` | Korean *(both values)* · Painting · Under $5,000 |
| `african american photography` | Photography, keyword “african american” — no nationality |
| `chinese` | a bare demonym |
| `chinese ceramics` |no filter backs it up |
| `american warhol` | an artist name |
| `nationality under 5k` | a price alone can’t back a nationality |
| `not chinese photography` | negated |