### PR TITLE
feat(suggested-search): add tracking and the nationality preposition

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "make-fetch-happen@npm:^13.0.1": "^14.0.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.395.0",
+    "@artsy/cohesion": "4.396.0",
     "@artsy/detect-responsive-traits": "^0.2.0",
     "@artsy/dismissible": "^0.9.0",
     "@artsy/express-reloadable": "^1.7.0",

--- a/src/Components/Search/Mobile/SearchResultsList.tsx
+++ b/src/Components/Search/Mobile/SearchResultsList.tsx
@@ -1,10 +1,11 @@
 import {
   ActionType,
   ContextModule,
-  type RailViewed,
   type SearchedWithNoResults,
   type SearchedWithResults,
+  type SearchedWithSuggestedFilter,
   type SelectedItemFromSearch,
+  type SelectedSuggestedFilter,
 } from "@artsy/cohesion"
 import { Flex, Spinner } from "@artsy/palette"
 import { InfiniteScrollSentinel } from "Components/InfiniteScrollSentinel"
@@ -68,22 +69,39 @@ export const SearchResultsList: FC<
   const shouldShowSuggestedFilters =
     !!parsedFilters && selectedPill === TOP_PILL
 
-  // Once per overlay session; per keystroke would inflate the CTR denominator
-  const hasTrackedSuggestedFiltersRef = useRef(false)
+  // Once per distinct filter set, not per keystroke: "chinese photo" and
+  // "chinese photography" parse the same, so refining a query records the
+  // intent once. Matches the desktop search bar.
+  const trackedFilterSetsRef = useRef(new Set<string>())
 
   useEffect(() => {
-    if (!shouldShowSuggestedFilters) return
-    if (hasTrackedSuggestedFiltersRef.current) return
+    if (!shouldShowSuggestedFilters || !parsedFilters) return
 
-    hasTrackedSuggestedFiltersRef.current = true
+    const filters = JSON.stringify(parsedFilters.filters)
 
-    const event: RailViewed = {
-      action: ActionType.railViewed,
+    if (trackedFilterSetsRef.current.has(filters)) return
+
+    trackedFilterSetsRef.current.add(filters)
+
+    const event: SearchedWithSuggestedFilter = {
+      action: ActionType.searchedWithSuggestedFilter,
       context_module: ContextModule.suggestedFilters,
-      context_screen: contextPageOwnerType,
+      context_owner_type: contextPageOwnerType,
+      context_owner_id: contextPageOwnerId,
+      context_owner_slug: contextPageOwnerSlug,
+      filters,
+      query: debouncedQuery,
     }
     tracking.trackEvent(event)
-  }, [shouldShowSuggestedFilters, contextPageOwnerType, tracking.trackEvent])
+  }, [
+    shouldShowSuggestedFilters,
+    parsedFilters,
+    debouncedQuery,
+    contextPageOwnerType,
+    contextPageOwnerId,
+    contextPageOwnerSlug,
+    tracking.trackEvent,
+  ])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
@@ -148,15 +166,13 @@ export const SearchResultsList: FC<
   }
 
   const handleSuggestedFiltersClick = () => {
-    const event: SelectedItemFromSearch = {
-      action: ActionType.selectedItemFromSearch,
-      // Its own module, separable from entity results
+    if (!parsedFilters) return
+
+    const event: SelectedSuggestedFilter = {
+      action: ActionType.selectedSuggestedFilter,
       context_module: ContextModule.suggestedFilters,
-      destination_path: suggestedFiltersOption.href,
+      filters: JSON.stringify(parsedFilters.filters),
       query: debouncedQuery,
-      item_id: suggestedFiltersOption.item_id!,
-      item_number: suggestedFiltersOption.item_number!,
-      item_type: suggestedFiltersOption.item_type!,
     }
 
     tracking.trackEvent(event)

--- a/src/Components/Search/Mobile/__tests__/SearchResultsList.jest.tsx
+++ b/src/Components/Search/Mobile/__tests__/SearchResultsList.jest.tsx
@@ -143,26 +143,29 @@ describe("SearchResultsList", () => {
         />,
       )
 
-      const railViewed = mockTrackEvent.mock.calls.filter(([event]) => {
-        return event.action === ActionType.railViewed
+      const impressions = mockTrackEvent.mock.calls.filter(([event]) => {
+        return event.action === ActionType.searchedWithSuggestedFilter
       })
 
-      expect(railViewed).toHaveLength(1)
-      expect(railViewed[0][0]).toMatchObject({
+      expect(impressions).toHaveLength(1)
+      expect(impressions[0][0]).toMatchObject({
         context_module: ContextModule.suggestedFilters,
+        query: QUERY,
+      })
+      expect(JSON.parse(impressions[0][0].filters)).toMatchObject({
+        medium: "prints",
       })
     })
 
-    it("tracks its own context module on click, and closes the overlay", () => {
+    it("tracks the click with its filters, and closes the overlay", () => {
       renderList()
       row()?.click()
 
       expect(mockTrackEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          action: ActionType.selectedItemFromSearch,
+          action: ActionType.selectedSuggestedFilter,
           context_module: ContextModule.suggestedFilters,
-          item_id: "suggested-filters",
-          item_type: "filter-suggestion",
+          query: QUERY,
         }),
       )
       expect(mockOnClose).toHaveBeenCalled()

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -16,10 +16,11 @@ import styled from "styled-components"
 import {
   ActionType,
   ContextModule,
-  type RailViewed,
   type SearchedWithNoResults,
   type SearchedWithResults,
+  type SearchedWithSuggestedFilter,
   type SelectedItemFromSearch,
+  type SelectedSuggestedFilter,
 } from "@artsy/cohesion"
 import { Z } from "Apps/Components/constants"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
@@ -50,7 +51,10 @@ import { useTrendingImpressionSession } from "./hooks/useTrendingImpressionSessi
 import { getLabel } from "./utils/getLabel"
 import { isModifiedClick } from "./utils/isModifiedClick"
 import { buildSuggestedFiltersUrl } from "./utils/buildSuggestedFiltersUrl"
-import { parseFilterQuery } from "./utils/parseFilterQuery"
+import {
+  type ParsedFilterQuery,
+  parseFilterQuery,
+} from "./utils/parseFilterQuery"
 import { shouldSubmitToFilters } from "./utils/shouldSubmitToFilters"
 import { searchResultsHref } from "./utils/searchResultsHref"
 import { shouldStartSearching } from "./utils/shouldStartSearching"
@@ -301,7 +305,7 @@ export const SearchBarInput: FC<
     const href = parsed ? buildSuggestedFiltersUrl(parsed) : encodedSearchURL
 
     if (parsed) {
-      trackSelection(buildSuggestedFiltersOption({ query: term, href }))
+      trackSelection(buildSuggestedFiltersOption({ query: term, href }), parsed)
     }
 
     addRecentSearch({ label: term, href })
@@ -309,19 +313,28 @@ export const SearchBarInput: FC<
     redirect(href)
   }
 
-  const trackSelection = (option: SuggestionItemOptionProps) => {
+  const trackSelection = (
+    option: SuggestionItemOptionProps,
+    parsed?: ParsedFilterQuery | null,
+  ) => {
     // The "See all results" footer has never been tracked here
     if (option.kind === "footer") return
 
-    // Its own module, so the row's clicks are separable from entity results
-    const contextModule =
-      option.kind === "suggestedFilters"
-        ? ContextModule.suggestedFilters
-        : selectedPill.analyticsContextModule
+    // The row has its own event, carrying the filters it was parsed into
+    if (option.kind === "suggestedFilters" && parsed) {
+      const selectedEvent: SelectedSuggestedFilter = {
+        action: ActionType.selectedSuggestedFilter,
+        context_module: ContextModule.suggestedFilters,
+        filters: JSON.stringify(parsed.filters),
+        query: value,
+      }
+      tracking.trackEvent(selectedEvent)
+      return
+    }
 
     const analyticsEvent: SelectedItemFromSearch = {
       action: ActionType.selectedItemFromSearch,
-      context_module: contextModule,
+      context_module: selectedPill.analyticsContextModule,
       destination_path: option.href,
       query: value,
       item_id: option.item_id!,
@@ -332,7 +345,7 @@ export const SearchBarInput: FC<
   }
 
   const handleSelect = (option: SuggestionItemOptionProps) => {
-    trackSelection(option)
+    trackSelection(option, parsedFilters)
     // The “See all results” footer row records the raw query + results page,
     // the same entry a plain Enter submit records
     addRecentSearchFromOption(option)
@@ -346,7 +359,7 @@ export const SearchBarInput: FC<
     option: SuggestionItemOptionProps,
     event?: MouseEvent<HTMLElement>,
   ) => {
-    trackSelection(option)
+    trackSelection(option, parsedFilters)
     addRecentSearchFromOption(option)
     if (isModifiedClick(event)) return
     closeDropdown()
@@ -367,31 +380,43 @@ export const SearchBarInput: FC<
     redirect(`${option.href}/auction-results`)
   }
 
-  // Once per focus session, not per keystroke: the row changes as the query is
-  // refined, and counting each appearance would inflate the CTR denominator.
-  const hasTrackedSuggestedFiltersRef = useRef(false)
+  // Once per distinct filter set, not per keystroke: "chinese photo" and
+  // "chinese photography" parse to the same filters, so refining a query
+  // records the intent once rather than once a letter.
+  const trackedFilterSetsRef = useRef(new Set<string>())
 
   useEffect(() => {
     if (!isFocused) {
-      hasTrackedSuggestedFiltersRef.current = false
+      trackedFilterSetsRef.current.clear()
       return
     }
 
-    if (!shouldShowSuggestedFilters) return
-    if (hasTrackedSuggestedFiltersRef.current) return
+    if (!shouldShowSuggestedFilters || !parsedFilters) return
 
-    hasTrackedSuggestedFiltersRef.current = true
+    const filters = JSON.stringify(parsedFilters.filters)
 
-    const event: RailViewed = {
-      action: ActionType.railViewed,
+    if (trackedFilterSetsRef.current.has(filters)) return
+
+    trackedFilterSetsRef.current.add(filters)
+
+    const event: SearchedWithSuggestedFilter = {
+      action: ActionType.searchedWithSuggestedFilter,
       context_module: ContextModule.suggestedFilters,
-      context_screen: contextPageOwnerType,
+      context_owner_type: contextPageOwnerType,
+      context_owner_id: contextPageOwnerId,
+      context_owner_slug: contextPageOwnerSlug,
+      filters,
+      query: debouncedValue,
     }
     tracking.trackEvent(event)
   }, [
     isFocused,
     shouldShowSuggestedFilters,
+    parsedFilters,
+    debouncedValue,
     contextPageOwnerType,
+    contextPageOwnerId,
+    contextPageOwnerSlug,
     tracking.trackEvent,
   ])
 

--- a/src/Components/Search/SuggestedFiltersItem.tsx
+++ b/src/Components/Search/SuggestedFiltersItem.tsx
@@ -36,11 +36,7 @@ export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
     event.stopPropagation()
   }
 
-  // Headline is the free text, second line is what it's filtered to. With no
-  // free text the filters become the headline — promoting just the first one
-  // made "unique prints under 10000" read as "Prints" in "Under $10,000".
-  const title = parsed.keyword || parsed.labels.join(LABEL_SEPARATOR)
-  const detail = parsed.keyword ? parsed.labels.join(LABEL_SEPARATOR) : null
+  const { title, detail } = getRowText(parsed)
 
   return (
     <SuggestedFiltersLink
@@ -75,6 +71,34 @@ export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
       </Flex>
     </SuggestedFiltersLink>
   )
+}
+
+// Headline is the free text, second line is what it's filtered to. With no
+// free text a nationality takes the headline — "Chinese" in "Photography"
+// reads the way language does. Nothing else does: promoting the first label
+// made "unique prints under 10000" read as "Prints" in "Under $10,000", so
+// every other case keeps the filters on one line.
+const getRowText = (
+  parsed: ParsedFilterQuery,
+): { title: string; detail: string | null } => {
+  const { keyword, labels, nationalityLabels } = parsed
+
+  if (keyword) {
+    return { title: keyword, detail: labels.join(LABEL_SEPARATOR) }
+  }
+
+  if (nationalityLabels.length > 0) {
+    const rest = labels.filter(label => {
+      return !nationalityLabels.includes(label)
+    })
+
+    return {
+      title: nationalityLabels.join(LABEL_SEPARATOR),
+      detail: rest.join(LABEL_SEPARATOR),
+    }
+  }
+
+  return { title: labels.join(LABEL_SEPARATOR), detail: null }
 }
 
 // Tinted so the row reads as a suggestion. Its resting state is the entity

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -604,7 +604,7 @@ describe("SearchBarInput", () => {
       expect(row()).not.toBeInTheDocument()
     })
 
-    it("tracks the click under its own context module", async () => {
+    it("tracks the click with the filters it parsed", async () => {
       enableSuggestedFilters()
       render(<SearchBarInput searchTerm="warhol prints under 5000" />)
 
@@ -612,11 +612,14 @@ describe("SearchBarInput", () => {
 
       expect(mockTrackEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          action: ActionType.selectedItemFromSearch,
+          action: ActionType.selectedSuggestedFilter,
           context_module: ContextModule.suggestedFilters,
-          item_id: "suggested-filters",
-          item_number: 0,
-          item_type: "filter-suggestion",
+          filters: JSON.stringify({
+            medium: "prints",
+            priceRange: "*-5000",
+            keyword: "warhol",
+          }),
+          query: "warhol prints under 5000",
         }),
       )
     })
@@ -635,20 +638,42 @@ describe("SearchBarInput", () => {
       )
     })
 
-    it("tracks one impression per focus session", () => {
+    const impressions = () => {
+      return mockTrackEvent.mock.calls.filter(([event]) => {
+        return event.action === ActionType.searchedWithSuggestedFilter
+      })
+    }
+
+    it("tracks the appearance with the filters it parsed", () => {
       enableSuggestedFilters()
       render(<SearchBarInput searchTerm="warhol prints under 5000" />)
 
       fireEvent.focus(screen.getByRole("textbox"))
 
-      const impressions = mockTrackEvent.mock.calls.filter(([event]) => {
-        return (
-          event.action === ActionType.railViewed &&
-          event.context_module === ContextModule.suggestedFilters
-        )
-      })
+      expect(impressions()).toHaveLength(1)
+      expect(impressions()[0][0]).toEqual(
+        expect.objectContaining({
+          context_module: ContextModule.suggestedFilters,
+          filters: JSON.stringify({
+            medium: "prints",
+            priceRange: "*-5000",
+            keyword: "warhol",
+          }),
+          query: "warhol prints under 5000",
+        }),
+      )
+    })
 
-      expect(impressions).toHaveLength(1)
+    it("tracks one impression per distinct filter set", async () => {
+      // "prints under 5000" parses the same either way, so refining the query
+      // records the intent once rather than once a letter
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      fireEvent.focus(screen.getByRole("textbox"))
+      await userEvent.type(screen.getByRole("textbox"), "!")
+
+      expect(impressions()).toHaveLength(1)
     })
 
     it("does not track an impression before the dropdown is focused", () => {
@@ -656,7 +681,9 @@ describe("SearchBarInput", () => {
       render(<SearchBarInput searchTerm="warhol prints under 5000" />)
 
       expect(mockTrackEvent).not.toHaveBeenCalledWith(
-        expect.objectContaining({ action: ActionType.railViewed }),
+        expect.objectContaining({
+          action: ActionType.searchedWithSuggestedFilter,
+        }),
       )
     })
 
@@ -695,7 +722,7 @@ describe("SearchBarInput", () => {
         expect(recent.href).toContain("additional_gene_ids")
       })
 
-      it("tracks the submit under the suggested filters module", async () => {
+      it("tracks the submit as a suggested filter selection", async () => {
         enableSuggestedFilters()
         render(<SearchBarInput searchTerm="warhol prints under 5000" />)
 
@@ -703,9 +730,9 @@ describe("SearchBarInput", () => {
 
         expect(mockTrackEvent).toHaveBeenCalledWith(
           expect.objectContaining({
-            action: ActionType.selectedItemFromSearch,
+            action: ActionType.selectedSuggestedFilter,
             context_module: ContextModule.suggestedFilters,
-            item_id: "suggested-filters",
+            query: "warhol prints under 5000",
           }),
         )
       })

--- a/src/Components/Search/__tests__/SuggestedFiltersItem.jest.tsx
+++ b/src/Components/Search/__tests__/SuggestedFiltersItem.jest.tsx
@@ -19,24 +19,36 @@ describe("SuggestedFiltersItem", () => {
     })
   })
 
-  const parsed = (keyword: string, labels: string[]): ParsedFilterQuery => {
-    return { filters: {}, keyword, labels, termLabel: labels[0] }
+  const parsed = (
+    keyword: string,
+    labels: string[],
+    nationalityLabels: string[] = [],
+  ): ParsedFilterQuery => {
+    return {
+      filters: {},
+      keyword,
+      labels,
+      nationalityLabels,
+      termLabel: labels[0],
+    }
   }
 
   const renderRow = ({
     keyword,
     labels,
+    nationalityLabels,
     query,
     onClick = jest.fn(),
   }: {
     keyword: string
     labels: string[]
+    nationalityLabels?: string[]
     query: string
     onClick?: () => void
   }) => {
     render(
       <SuggestedFiltersItem
-        parsed={parsed(keyword, labels)}
+        parsed={parsed(keyword, labels, nationalityLabels)}
         href="/collect/prints"
         query={query}
         onClick={onClick}
@@ -94,6 +106,45 @@ describe("SuggestedFiltersItem", () => {
 
       expect(row).toHaveTextContent("Prints · $1,000–$5,000")
       expect(row).not.toHaveTextContent("in ")
+    })
+  })
+
+  describe("when a nationality leads the query", () => {
+    // A demonym is a subject and a medium is a container, so the preposition
+    // reads the way language does — unlike a rarity or a price
+    it("puts the nationality in the headline and the rest behind “in”", () => {
+      const row = renderRow({
+        keyword: "",
+        labels: ["Chinese", "Photography"],
+        nationalityLabels: ["Chinese"],
+        query: "chinese photography",
+      })
+
+      expect(row).toHaveTextContent("Chinese")
+      expect(row).toHaveTextContent("in Photography")
+    })
+
+    it("keeps the remaining filters together behind the preposition", () => {
+      const row = renderRow({
+        keyword: "",
+        labels: ["Korean", "Painting", "Under $5,000"],
+        nationalityLabels: ["Korean"],
+        query: "korean paintings under 5k",
+      })
+
+      expect(row).toHaveTextContent("in Painting · Under $5,000")
+    })
+
+    it("leaves the free text in the headline when there is some", () => {
+      const row = renderRow({
+        keyword: "warhol",
+        labels: ["Chinese", "Prints"],
+        nationalityLabels: ["Chinese"],
+        query: "chinese warhol prints",
+      })
+
+      expect(row).toHaveTextContent("warhol")
+      expect(row).toHaveTextContent("in Chinese · Prints")
     })
   })
 

--- a/src/Components/Search/utils/parseFilterQuery.ts
+++ b/src/Components/Search/utils/parseFilterQuery.ts
@@ -31,6 +31,8 @@ export interface ParsedFilterQuery {
   keyword: string
   /** Human labels in display order: nationality, medium, rarity, price */
   labels: string[]
+  /** The leading nationality labels, which read as a subject of their own */
+  nationalityLabels: string[]
   /**
    * Stands in as the search term when there is no free text. The medium is the
    * only label that reads as one: a rarity or a nationality repeated as a
@@ -405,6 +407,7 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
     },
     keyword,
     labels,
+    nationalityLabels,
     termLabel: medium?.label ?? labels[0],
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,12 +21,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.395.0":
-  version: 4.395.0
-  resolution: "@artsy/cohesion@npm:4.395.0"
+"@artsy/cohesion@npm:4.396.0":
+  version: 4.396.0
+  resolution: "@artsy/cohesion@npm:4.396.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/cb9f51258819e25fb0544c848f59b93020748c5f8b1e549a79c7f7a26c813bab4c4e1d3a5c8ffca30019f2c5ddadfb3677f98068966f0ab1c18cdddb5ced50a5
+  checksum: 10c0/9ea42dd1fc855abb29f985171dd1147765a21240b3454410df21a1692dd481ca064b1d680c381acdd5f26105539f574fde5ecf694123073cb53a832d57bb4f0e
   languageName: node
   linkType: hard
 
@@ -9437,7 +9437,7 @@ __metadata:
   resolution: "force@workspace:."
   dependencies:
     "@artaio/arta-browser": "npm:^2.16.1"
-    "@artsy/cohesion": "npm:4.395.0"
+    "@artsy/cohesion": "npm:4.396.0"
     "@artsy/detect-responsive-traits": "npm:^0.2.0"
     "@artsy/dismissible": "npm:^0.9.0"
     "@artsy/express-reloadable": "npm:^1.7.0"


### PR DESCRIPTION
### Description

A nationality now leads the row with the rest behind the grey `in` — `chinese photography` shows as **Chinese** / *in Photography* instead of one flat line. Tracking moves to the two dedicated cohesion events, `searchedWithSuggestedFilter` when the row appears and `selectedSuggestedFilter` when it’s taken, both carrying the parsed filters and the query. The appearance event fires once per distinct filter set rather than per keystroke, so `chinese photo` and/or `chinese photography` only record once.

# Before
<img width="1567" height="366" alt="image" src="https://github.com/user-attachments/assets/79914a02-e5c1-472e-8f9b-a048cd5cb584" />

# After 

<img width="1747" height="858" alt="image" src="https://github.com/user-attachments/assets/d72b7368-b55c-429a-a40a-00a386dc0d34" />
