### PR TITLE
feat(search): animate the search placeholder with typewriter suggestions

### DIFF
--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -45,19 +45,26 @@ import {
   type SuggestionItemOptionProps,
 } from "./SuggestionItem/SuggestionItem"
 import { TrendingSearches } from "./TrendingSearches/TrendingSearches"
-import { type PillType, SEARCH_DEBOUNCE_DELAY, TOP_PILL } from "./constants"
+import {
+  type PillType,
+  SEARCH_DEBOUNCE_DELAY,
+  SEARCH_PLACEHOLDER,
+  SEARCH_PLACEHOLDER_SUGGESTIONS,
+  TOP_PILL,
+} from "./constants"
 import { useRecentSearches } from "./hooks/useRecentSearches"
 import { useTrendingImpressionSession } from "./hooks/useTrendingImpressionSession"
+import { useTypewriterPlaceholder } from "./hooks/useTypewriterPlaceholder"
+import { buildSuggestedFiltersUrl } from "./utils/buildSuggestedFiltersUrl"
 import { getLabel } from "./utils/getLabel"
 import { isModifiedClick } from "./utils/isModifiedClick"
-import { buildSuggestedFiltersUrl } from "./utils/buildSuggestedFiltersUrl"
 import {
   type ParsedFilterQuery,
   parseFilterQuery,
 } from "./utils/parseFilterQuery"
-import { shouldSubmitToFilters } from "./utils/shouldSubmitToFilters"
 import { searchResultsHref } from "./utils/searchResultsHref"
 import { shouldStartSearching } from "./utils/shouldStartSearching"
+import { shouldSubmitToFilters } from "./utils/shouldSubmitToFilters"
 
 export interface SearchBarInputProps {
   searchTerm: string
@@ -111,6 +118,15 @@ export const SearchBarInput: FC<
   const edges = data?.viewer?.searchConnection?.edges ?? []
 
   const isSuggestedFiltersEnabled = useFlag("onyx_suggested-filters")
+
+  // Deliberately keeps animating while focused; only typing pauses it
+  const placeholder = useTypewriterPlaceholder({
+    phrases: SEARCH_PLACEHOLDER_SUGGESTIONS,
+    fallback: SEARCH_PLACEHOLDER,
+    isEnabled: isSuggestedFiltersEnabled && !value,
+    prefix: "Try “",
+    suffix: "”",
+  })
 
   // Debounced, not live: the row is prepended, so appearing per keystroke
   // shifts option indices under the cursor. Gated here rather than at render
@@ -518,7 +534,9 @@ export const SearchBarInput: FC<
           forwardRef={ref}
           key={match.location.pathname}
           value={value}
-          placeholder="Search by artist, gallery, style, theme, tag, etc."
+          placeholder={placeholder}
+          // Stable name for screen readers while the placeholder animates
+          aria-label="Search Artsy"
           spellCheck={false}
           options={shouldStartSearching(value) ? formattedOptions : []}
           defaultValue={value}

--- a/src/Components/Search/StaticSearchContainer.tsx
+++ b/src/Components/Search/StaticSearchContainer.tsx
@@ -2,6 +2,7 @@ import { Box, type BoxProps } from "@artsy/palette"
 import type { FC } from "react"
 
 import { NavBarSearchInputContainer } from "./NavBarSearchInputContainer"
+import { SEARCH_PLACEHOLDER } from "./constants"
 
 /**
  * Displays during SSR render.
@@ -20,9 +21,7 @@ export const StaticSearchContainer: FC<
 
       <Box display={["none", "block"]} {...rest}>
         <NavBarSearchInputContainer
-          placeholder={
-            searchQuery || "Search by artist, gallery, style, theme, tag, etc."
-          }
+          placeholder={searchQuery || SEARCH_PLACEHOLDER}
           defaultValue={searchQuery}
         />
       </Box>

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -49,6 +49,11 @@ jest.mock("@artsy/palette", () => ({
 
 jest.mock("System/Hooks/useRouter", () => ({ useRouter: jest.fn() }))
 
+// Its real timers would fire mid-test and trigger act warnings
+jest.mock("../hooks/useTypewriterPlaceholder", () => ({
+  useTypewriterPlaceholder: ({ fallback }: { fallback: string }) => fallback,
+}))
+
 jest.mock("../utils/parseFilterQuery", () => ({
   parseFilterQuery: jest.fn(
     jest.requireActual("../utils/parseFilterQuery").parseFilterQuery,

--- a/src/Components/Search/constants.ts
+++ b/src/Components/Search/constants.ts
@@ -90,3 +90,14 @@ export const PILLS: PillType[] = [
 ]
 
 export const SEARCH_DEBOUNCE_DELAY = 150
+
+export const SEARCH_PLACEHOLDER =
+  "Search by artist, gallery, style, theme, tag, etc."
+
+export const SEARCH_PLACEHOLDER_SUGGESTIONS = [
+  "Japanese paintings under $2,000",
+  "Fashion photography",
+  "Unique prints under $500",
+  "Abstract sculpture",
+  "French limited edition prints",
+]

--- a/src/Components/Search/hooks/__tests__/useTypewriterPlaceholder.jest.ts
+++ b/src/Components/Search/hooks/__tests__/useTypewriterPlaceholder.jest.ts
@@ -1,0 +1,174 @@
+import { act, renderHook } from "@testing-library/react-hooks"
+import {
+  TYPEWRITER_ERASE_DELAY,
+  TYPEWRITER_GAP_DELAY,
+  TYPEWRITER_HOLD_DELAY,
+  TYPEWRITER_TYPE_DELAY,
+  useTypewriterPlaceholder,
+} from "Components/Search/hooks/useTypewriterPlaceholder"
+
+const PHRASES = ["Cats", "Dog"]
+const FALLBACK = "Search Artsy"
+
+const setup = (isEnabled = true) => {
+  return renderHook(
+    ({ enabled }: { enabled: boolean }) => {
+      return useTypewriterPlaceholder({
+        phrases: PHRASES,
+        fallback: FALLBACK,
+        isEnabled: enabled,
+      })
+    },
+    { initialProps: { enabled: isEnabled } },
+  )
+}
+
+const advance = (ms: number) => {
+  act(() => {
+    jest.advanceTimersByTime(ms)
+  })
+}
+
+describe("useTypewriterPlaceholder", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("returns the fallback when disabled", () => {
+    const { result } = setup(false)
+
+    expect(result.current).toEqual(FALLBACK)
+
+    advance(10000)
+
+    expect(result.current).toEqual(FALLBACK)
+  })
+
+  it("types the first phrase character by character", () => {
+    const { result } = setup()
+
+    expect(result.current).toEqual("C")
+
+    advance(TYPEWRITER_TYPE_DELAY)
+    expect(result.current).toEqual("Ca")
+
+    advance(TYPEWRITER_TYPE_DELAY)
+    expect(result.current).toEqual("Cat")
+
+    advance(TYPEWRITER_TYPE_DELAY)
+    expect(result.current).toEqual("Cats")
+  })
+
+  it("holds the full phrase, then erases it", () => {
+    const { result } = setup()
+
+    advance(TYPEWRITER_TYPE_DELAY * 3)
+    expect(result.current).toEqual("Cats")
+
+    advance(TYPEWRITER_HOLD_DELAY - 1)
+    expect(result.current).toEqual("Cats")
+
+    advance(1)
+    expect(result.current).toEqual("Cat")
+
+    advance(TYPEWRITER_ERASE_DELAY * 3)
+    expect(result.current).toEqual("")
+  })
+
+  it("cycles to the next phrase and wraps around", () => {
+    const { result } = setup()
+
+    // Enters and exits with the first character typed, so cycles chain
+    // without timing drift
+    const cycle = (phrase: string) => {
+      advance(TYPEWRITER_TYPE_DELAY * (phrase.length - 1))
+      expect(result.current).toEqual(phrase)
+
+      advance(TYPEWRITER_HOLD_DELAY)
+      expect(result.current).toEqual(phrase.slice(0, -1))
+
+      advance(TYPEWRITER_ERASE_DELAY * (phrase.length - 1))
+      expect(result.current).toEqual("")
+
+      advance(TYPEWRITER_GAP_DELAY)
+    }
+
+    cycle("Cats")
+    expect(result.current).toEqual("D")
+
+    cycle("Dog")
+    expect(result.current).toEqual("C")
+  })
+
+  it("resets to the fallback when disabled mid-animation", () => {
+    const { result, rerender } = setup()
+
+    advance(TYPEWRITER_TYPE_DELAY * 2)
+    expect(result.current).toEqual("Cat")
+
+    rerender({ enabled: false })
+    expect(result.current).toEqual(FALLBACK)
+
+    advance(10000)
+    expect(result.current).toEqual(FALLBACK)
+  })
+
+  it("restarts from the beginning when re-enabled", () => {
+    const { result, rerender } = setup()
+
+    advance(TYPEWRITER_TYPE_DELAY * 3)
+    expect(result.current).toEqual("Cats")
+
+    rerender({ enabled: false })
+    rerender({ enabled: true })
+
+    expect(result.current).toEqual("C")
+  })
+
+  it("keeps the static frame around the animated text, but not the fallback", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => {
+        return useTypewriterPlaceholder({
+          phrases: PHRASES,
+          fallback: FALLBACK,
+          isEnabled: enabled,
+          prefix: "Try “",
+          suffix: "”",
+        })
+      },
+      { initialProps: { enabled: true } },
+    )
+
+    expect(result.current).toEqual("Try “C”")
+
+    advance(TYPEWRITER_TYPE_DELAY * 3)
+    expect(result.current).toEqual("Try “Cats”")
+
+    advance(TYPEWRITER_HOLD_DELAY)
+    expect(result.current).toEqual("Try “Cat”")
+
+    advance(TYPEWRITER_ERASE_DELAY * 3)
+    expect(result.current).toEqual("Try “”")
+
+    rerender({ enabled: false })
+    expect(result.current).toEqual(FALLBACK)
+  })
+
+  it("returns the fallback when the user prefers reduced motion", () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true })
+
+    const { result } = setup()
+
+    expect(result.current).toEqual(FALLBACK)
+
+    advance(10000)
+    expect(result.current).toEqual(FALLBACK)
+
+    window.matchMedia = originalMatchMedia
+  })
+})

--- a/src/Components/Search/hooks/useTypewriterPlaceholder.ts
+++ b/src/Components/Search/hooks/useTypewriterPlaceholder.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react"
+
+export const TYPEWRITER_TYPE_DELAY = 80
+export const TYPEWRITER_ERASE_DELAY = 40
+export const TYPEWRITER_HOLD_DELAY = 2000
+export const TYPEWRITER_GAP_DELAY = 600
+
+interface UseTypewriterPlaceholderProps {
+  /** Must be referentially stable; a new array restarts the animation */
+  phrases: string[]
+  fallback: string
+  isEnabled: boolean
+  /** Wraps only the animated text, never the fallback */
+  prefix?: string
+  suffix?: string
+}
+
+/** Types, holds, and erases each phrase in turn, looping forever */
+export const useTypewriterPlaceholder = ({
+  phrases,
+  fallback,
+  isEnabled,
+  prefix = "",
+  suffix = "",
+}: UseTypewriterPlaceholderProps): string => {
+  const [placeholder, setPlaceholder] = useState(fallback)
+
+  useEffect(() => {
+    // matchMedia is absent in jsdom
+    const prefersReducedMotion = window.matchMedia?.(
+      "(prefers-reduced-motion: reduce)",
+    )?.matches
+
+    if (!isEnabled || prefersReducedMotion || phrases.length === 0) {
+      setPlaceholder(fallback)
+      return
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout>
+    let phraseIndex = 0
+
+    const display = (text: string) => {
+      setPlaceholder(`${prefix}${text}${suffix}`)
+    }
+
+    const type = (length: number) => {
+      const phrase = phrases[phraseIndex]
+      display(phrase.slice(0, length))
+
+      if (length < phrase.length) {
+        timeoutId = setTimeout(() => type(length + 1), TYPEWRITER_TYPE_DELAY)
+        return
+      }
+
+      timeoutId = setTimeout(
+        () => erase(phrase.length - 1),
+        TYPEWRITER_HOLD_DELAY,
+      )
+    }
+
+    const erase = (length: number) => {
+      const phrase = phrases[phraseIndex]
+      display(phrase.slice(0, length))
+
+      if (length > 0) {
+        timeoutId = setTimeout(() => erase(length - 1), TYPEWRITER_ERASE_DELAY)
+        return
+      }
+
+      phraseIndex = (phraseIndex + 1) % phrases.length
+      timeoutId = setTimeout(() => type(1), TYPEWRITER_GAP_DELAY)
+    }
+
+    type(1)
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [isEnabled, phrases, fallback, prefix, suffix])
+
+  return placeholder
+}


### PR DESCRIPTION
## Summary

Adds an animated typewriter placeholder to the desktop header search bar, behind the existing `onyx_suggested-filters` flag. The placeholder cycles through example queries in a static `Try “…”` frame — the text inside the quotes is typed and erased one character at a time — to show what search can do (all example phrases resolve to a suggested-filters row).

## Behavior

- Desktop only; mobile keeps its static placeholder
- Keeps animating; pauses as soon as the first character is typed, resumes when cleared
- Falls back to the current static placeholder when the flag is off, during SSR, or when the user prefers reduced motion
- Stable `aria-label` so the accessible name doesn't churn for screen readers

## Notes
- New `useTypewriterPlaceholder` hook with its own test suite; it is mocked in the `SearchBarInput` suite so its timers don't interfere there

🤖 Generated with [Claude Code](https://claude.com/claude-code)