### PR TITLE
feat: POC for new onboarding flow

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -39,6 +39,7 @@ import { Media } from "Utils/Responsive"
 import { track } from "react-tracking"
 import { NavBarItemButton, NavBarItemLink } from "./NavBarItem"
 import { NavBarLoggedInActionsQueryRenderer } from "./NavBarLoggedInActions"
+import { OnboardingTooltipPOC } from "./OnboardingTooltipPOC"
 import { NavBarMobileMenuNotificationsIndicatorQueryRenderer } from "./NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator"
 import { NavBarPrimaryLogo } from "./NavBarPrimaryLogo"
 import { NavBarSkipLink } from "./NavBarSkipLink"
@@ -203,6 +204,18 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
               <Flex display={["none", "flex"]} ml={2} alignItems="stretch">
                 <Text variant="sm" lineHeight={1} display={["none", "flex"]}>
                   {DESKTOP_TOP_TIER.map(id => {
+                    if (id === "priceDatabase") {
+                      return (
+                        <OnboardingTooltipPOC key={id}>
+                          <NavBarDesktopItem
+                            item={NAV_ITEMS[id]}
+                            navigationData={navigationData}
+                            handleClick={handleClick}
+                          />
+                        </OnboardingTooltipPOC>
+                      )
+                    }
+
                     return (
                       <NavBarDesktopItem
                         key={id}

--- a/src/Components/NavBar/OnboardingTooltipPOC.tsx
+++ b/src/Components/NavBar/OnboardingTooltipPOC.tsx
@@ -1,0 +1,30 @@
+import { Text } from "@artsy/palette"
+import { Z } from "Apps/Components/constants"
+import { ProgressiveOnboardingPopover } from "Components/ProgressiveOnboarding/ProgressiveOnboardingPopover"
+import {
+  clearOnboardingInterestsPending,
+  useOnboardingInterestsPendingPOC,
+} from "Utils/onboardingInterestsPendingPOC"
+import type { FC } from "react"
+
+export const OnboardingTooltipPOC: FC<React.PropsWithChildren<unknown>> = ({
+  children,
+}) => {
+  const pendingInterests = useOnboardingInterestsPendingPOC()
+
+  if (pendingInterests.length === 0) {
+    return <>{children}</>
+  }
+
+  return (
+    <ProgressiveOnboardingPopover
+      name="onboarding-interests-poc"
+      placement="bottom"
+      zIndex={Z.globalNav + 1}
+      onClose={clearOnboardingInterestsPending}
+      popover={<Text variant="xs">{pendingInterests.join(", ")}</Text>}
+    >
+      {children}
+    </ProgressiveOnboardingPopover>
+  )
+}

--- a/src/Components/Onboarding/Components/OnboardingDialogPOC.tsx
+++ b/src/Components/Onboarding/Components/OnboardingDialogPOC.tsx
@@ -1,0 +1,106 @@
+import { Box, Button, Checkbox, Spacer, Text } from "@artsy/palette"
+import { OnboardingModal } from "Components/Onboarding/Components/OnboardingModal"
+import { markOnboardingInterestsPending } from "Utils/onboardingInterestsPendingPOC"
+import { type FC, useState } from "react"
+
+const INTERESTS = [
+  "Buying art",
+  "Discovering art for inspiration",
+  "Reading about art and artists",
+  "Tracking prices and results at auction",
+]
+
+const SOURCES = [
+  "Search engine",
+  "Social media",
+  "A friend or family member",
+  "Other",
+]
+
+interface OnboardingDialogPOCProps {
+  onClose(): void
+  onHide(): void
+}
+
+export const OnboardingDialogPOC: FC<
+  React.PropsWithChildren<OnboardingDialogPOCProps>
+> = ({ onClose, onHide }) => {
+  const [step, setStep] = useState<0 | 1>(0)
+  const [interests, setInterests] = useState<string[]>([])
+  const [source, setSource] = useState<string | null>(null)
+
+  const toggleInterest = (interest: string) => {
+    setInterests(current => {
+      return current.includes(interest)
+        ? current.filter(existing => existing !== interest)
+        : [...current, interest]
+    })
+  }
+
+  const handleFinish = () => {
+    markOnboardingInterestsPending(interests)
+    onHide()
+  }
+
+  return (
+    <OnboardingModal onClose={onClose}>
+      <Box p={4} width="100%">
+        <Text variant="lg-display" mb={4}>
+          {step === 0
+            ? "What are you most interested in?"
+            : "How did you hear about Artsy?"}
+        </Text>
+
+        {step === 0 && (
+          <Box>
+            {INTERESTS.map(interest => {
+              return (
+                <Box key={interest} mb={2}>
+                  <Checkbox
+                    selected={interests.includes(interest)}
+                    onSelect={() => toggleInterest(interest)}
+                  >
+                    {interest}
+                  </Checkbox>
+                </Box>
+              )
+            })}
+          </Box>
+        )}
+
+        {step === 1 && (
+          <Box>
+            {SOURCES.map(option => {
+              return (
+                <Box key={option} mb={2}>
+                  <Checkbox
+                    selected={source === option}
+                    onSelect={() => setSource(option)}
+                  >
+                    {option}
+                  </Checkbox>
+                </Box>
+              )
+            })}
+          </Box>
+        )}
+
+        <Spacer y={4} />
+
+        {step === 0 ? (
+          <Button
+            width="100%"
+            disabled={interests.length === 0}
+            onClick={() => setStep(1)}
+          >
+            Next
+          </Button>
+        ) : (
+          <Button width="100%" disabled={!source} onClick={handleFinish}>
+            Finish
+          </Button>
+        )}
+      </Box>
+    </OnboardingModal>
+  )
+}

--- a/src/Components/Onboarding/Hooks/useOnboarding.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboarding.tsx
@@ -5,9 +5,9 @@ const OnboardingDialog = loadable(
   () =>
     import(
       /* webpackChunkName: "onboardingBundle" */
-      "Components/Onboarding/Components/OnboardingDialog"
+      "Components/Onboarding/Components/OnboardingDialogPOC"
     ),
-  { resolveComponent: component => component.OnboardingDialog },
+  { resolveComponent: component => component.OnboardingDialogPOC },
 )
 
 interface UseOnboarding {
@@ -25,6 +25,7 @@ export const useOnboarding = ({ onClose }: UseOnboarding) => {
     setIsVisible(false)
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hideDialog is stable, only calls setIsVisible
   const dialogComponent = useMemo(() => {
     return (
       <>

--- a/src/Utils/onboardingInterestsPendingPOC.ts
+++ b/src/Utils/onboardingInterestsPendingPOC.ts
@@ -1,0 +1,52 @@
+import { useSyncExternalStore } from "react"
+
+const PENDING_KEY = "onboarding-interests-pending"
+
+const readPending = (): string[] => {
+  try {
+    const raw = sessionStorage.getItem(PENDING_KEY)
+
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+const listeners = new Set<() => void>()
+
+let snapshot: string[] = readPending()
+
+const setSnapshot = (next: string[]) => {
+  snapshot = next
+  listeners.forEach(listener => listener())
+}
+
+export const markOnboardingInterestsPending = (interests: string[]): void => {
+  try {
+    sessionStorage.setItem(PENDING_KEY, JSON.stringify(interests))
+  } catch {}
+
+  setSnapshot(interests)
+}
+
+export const clearOnboardingInterestsPending = (): void => {
+  try {
+    sessionStorage.removeItem(PENDING_KEY)
+  } catch {}
+
+  setSnapshot([])
+}
+
+const subscribe = (onChange: () => void): (() => void) => {
+  listeners.add(onChange)
+
+  return () => listeners.delete(onChange)
+}
+
+const getSnapshot = (): string[] => snapshot
+
+const getServerSnapshot = (): string[] => []
+
+export const useOnboardingInterestsPendingPOC = (): string[] => {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}


### PR DESCRIPTION
This is a POC for the new onboarding flow. It shows a 2-step questionnaire on sign-up, which saves the selected interests to sessionStorage on completion so a nav-bar tooltip (pointed at Price Database) can react once the modal closes.

This is a POC to validate the mechanism, not a spec-complete implementation.


https://github.com/user-attachments/assets/8d97a3eb-402e-4edd-9fbd-77853fc1a4fc


## What's oversimplified here

- No flow-identity check — always shows 2 steps, doesn't distinguish CTA/email sign-up from Google One Tap
- No commercial-intent exclusion — shows onboarding even for commercial sign-ups
- No account-completion side effects — doesn't fire tracking
- No "Other" free-text field, no modal resize/progress indicator, no dismiss-lockdown
- Only one hardcoded tooltip, regardless of which interests are picked

## What needs more thought before this is real

- **"What's New" anchor**: the spec's real target for most tooltip cases is a dropdown nav item that can render nothing and may visually collide with hover behavior. This POC dodges it by using Price Database instead.
- **z-index**: the header renders above the tooltip's default z-index; I overrode it for this one instance, worth checking whether other nav-anchored tooltips have the same issue.
- **Mobile/touch**: tooltips never show on touch devices and the desktop nav doesn't exist below the `xs` breakpoint, so this mechanism is desktop-only as designed — worth explicit sign-off given the target cohort.


🤖 Generated with [Claude Code](https://claude.com/claude-code)